### PR TITLE
Added backslash as escape character

### DIFF
--- a/dodo.c
+++ b/dodo.c
@@ -202,7 +202,7 @@ struct Instruction * parse_string(struct Instruction *i, char *source, size_t *i
                    Note the use of memmove as the source and destination overlap */
                 memmove(source+*index,
                         source+*index+1,
-                        strlen(i->argument.str) - ((i->argument.str - source) - *index) - 1);
+                        strlen(source+*index));
                 (*index)++;
                 len+=2;
                 break;

--- a/dodo.c
+++ b/dodo.c
@@ -197,6 +197,16 @@ struct Instruction * parse_string(struct Instruction *i, char *source, size_t *i
                 return 0;
                 break;
 
+            case '\\':
+                /* A bit yucky: Rework the string to delete the escape character '\'
+                   Note the use of memmove as the source and destination overlap */
+                memmove(source+*index,
+                        source+*index+1,
+                        strlen(i->argument.str) - ((i->argument.str - source) - *index) - 1);
+                (*index)++;
+                len+=2;
+                break;
+
             /* terminating delimiter */
             case '/':
                 /* skip past / */

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ TESTFILENAME="tmp_testing_file";
 
 echo -e "\nWriting file"
 cat <<EOF > $TESTFILENAME
-hello world how are you
+hello world how are you mutter mutter sl/ash
 EOF
 
 echo -e "\nRunning dodo"
@@ -16,12 +16,15 @@ echo -e "\nRunning dodo"
     b6         # goto byte 6 in file
     e/world/   # expect string 'world'
     w/marge/   # write string 'marge' (writes over 'world')
+    b38
+    e/sl\/ash/ # expect string 'sl/ash'
+    w/slashy/  # write string 'sl/ash' with 'slashy'
     q          # quit
 EOF
 
 echo -e "\nComparing output"
 GOT=`cat $TESTFILENAME`
-EXPECTED="hello marge how are you"
+EXPECTED="hello marge how are you mutter mutter slashy"
 
 if [ ! "$GOT" = "$EXPECTED" ]; then
     echo -e "\nTest failed:"


### PR DESCRIPTION
I've added the ability for dodo to encounter use a backslash as a sort-of escape character. It simply causes dodo to `memmove()` everything down and skip checking the character immediately after the backslash (now in the backslash's place) for null, '\' or '/'.
The calls to memmove are potentially a source of slowness, but it was the quickest way to slot this functionality into dodo.
