### PR TITLE
Fixed dist tarball creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dodo
 dodo.o
 tmp_testing_file
+dodo-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,11 @@ clean:
 	@rm -f dodo ${OBJ} dodo-${VERSION}.tar.gz
 
 dist: clean
-	@echo creating dist tarball
+	@echo creating dist tarball 'dodo-${VERSION}.tar.gz'
 	@mkdir -p dodo-${VERSION}
-	@cp -R LICENSE Makefile config.mk \
-		README TODO dodo.1 codes.h ${SRC} dodo-${VERSION}
+	@cp -R config.mk dodo.1 LICENSE \
+		Makefile README.md test.sh ${SRC} \
+		dodo-${VERSION}
 	@tar -cf dodo-${VERSION}.tar dodo-${VERSION}
 	@gzip dodo-${VERSION}.tar
 	@rm -rf dodo-${VERSION}


### PR DESCRIPTION
Makefile's recipe for creating a dist tarball was outdated, referring to files which no longer existed.
This commit:
1. fixes this recipe
2. adds a slightly more verbose message when the recipe is run
3. adds to the gitignore so as to ignore dist tarballs created
