### PR TITLE
Implement a repl, fix misc memory leaks

### DIFF
--- a/dodo.1
+++ b/dodo.1
@@ -11,7 +11,7 @@ dodo - a scriptable in-place file ditor
 
 .SH DESCRIPTION
 dodo is a non-interactive scriptable in place file editor.
-It takes exactly 1 argument, the file to work on, and it takes its program input from stdin.
+It takes the file to work on as an argument, and it takes its program input from stdin.
 .P
 dodo was born from the need to efficiently edit very large files (16GB plain sql dumps),
 I was unable to so using my normal toolset (ed, sed or vim) and I realised that writing a tool
@@ -24,15 +24,17 @@ going to modify using dodo.
 
 
 .SH USAGE
-dodo is run and supplied with a single argument representing the filename to work on.
+dodo is run and supplied with its last argument representing the filename to work on.
 dodo then reads its commands from stdin.
-Note that dodo is non-interactive so will not start work until its stdin input is finished (it sees EOF).
+In its default mode, dodo is non-interactive so will not start work until its stdin input is finished (it sees EOF).
+An optional 'interactive' mode is available in which dodo provides a prompt and executes its input upon a carriage return.
+This is especially useful for playing with the language amongst other things.
 In dodo all changes are flushed immediately; there are no concepts of 'saving', 'undo' or 'backups'.
 
 dodo is really a very thin wrapper around `fread` and `fwrite`.
 
 
-.IP "./dodo filename <<EOF"
+.IP "./dodo [-i|--interactive] filename <<EOF"
  p          # print 100 bytes
  p5         # print 5 bytes ('hello')
  e/hello/   # expect string 'hello'

--- a/dodo.c
+++ b/dodo.c
@@ -257,6 +257,7 @@ struct Instruction * parse_number(struct Instruction *i, char *source, size_t *i
     /* read in number */
     if( ! sscanf(&(source[*index]), "%d", &(i->argument.num)) ){
         puts("Parse_number: failed to read in number");
+        free(i);
         return 0;
     }
 
@@ -287,6 +288,7 @@ EXIT:
 }
 
 struct Instruction * parse_print(char *source, size_t *index){
+    struct Instruction *ret = 0;
     struct Instruction *i = 0;
 
     i = new_instruction(PRINT);
@@ -304,6 +306,7 @@ struct Instruction * parse_print(char *source, size_t *index){
 
         default:
             printf("Parse_print: unexpected character '%c', expected 'w'\n", source[*index]);
+            free(i);
             return 0;
             break;
     }
@@ -314,7 +317,10 @@ struct Instruction * parse_print(char *source, size_t *index){
      * if next character is a number then we are in the first form
      */
     if( isdigit(source[*index]) ){
-        return parse_number(i, source, index);
+        ret = parse_number(i, source, index);
+        if (ret == 0)
+            free(ret);
+        return ret;
     }
 
     /* otherwise there is no number and we are in second form (default to 100 bytes) */
@@ -322,6 +328,7 @@ struct Instruction * parse_print(char *source, size_t *index){
 }
 
 struct Instruction * parse_byte(char *source, size_t *index){
+    struct Instruction *ret = 0;
     struct Instruction *i = 0;
 
     i = new_instruction(BYTE);
@@ -338,10 +345,16 @@ struct Instruction * parse_byte(char *source, size_t *index){
             break;
         default:
             printf("Unexpected character '%c', expected 'b'\n", source[*index]);
+            free(i);
+            return 0;
             break;
     }
 
-    return parse_number(i, source, index);
+    ret = parse_number(i, source, index);
+    if (ret == 0)
+        free(ret);
+
+    return ret;
 }
 
 struct Instruction * parse_line(char *source, size_t *index){
@@ -353,11 +366,14 @@ struct Instruction * parse_line(char *source, size_t *index){
         return 0;
     }
 
+    free(i);
+
     puts("parse_line unimplemented");
     return 0; /* FIXME unimplemented */
 }
 
 struct Instruction * parse_expect(char *source, size_t *index){
+    struct Instruction *ret = 0;
     struct Instruction *i = 0;
 
     i = new_instruction(EXPECT);
@@ -375,14 +391,20 @@ struct Instruction * parse_expect(char *source, size_t *index){
 
         default:
             printf("Parse_expect: unexpected character '%c', expected 'e'\n", source[*index]);
+            free(i);
             return 0;
             break;
     }
 
-    return parse_string(i, source, index);
+    ret = parse_string(i, source, index);
+    if (ret == 0)
+        free(i);
+
+    return ret;
 }
 
 struct Instruction * parse_write(char *source, size_t *index){
+    struct Instruction *ret = 0;
     struct Instruction *i = 0;
 
     i = new_instruction(WRITE);
@@ -400,11 +422,15 @@ struct Instruction * parse_write(char *source, size_t *index){
 
         default:
             printf("Parse_write: unexpected character '%c', expected 'w'\n", source[*index]);
+            free(i);
             return 0;
             break;
     }
+    ret = parse_string(i, source, index);
+    if (ret == 0)
+        free(i);
 
-    return parse_string(i, source, index);
+    return ret;
 }
 
 struct Instruction * parse_quit(char *source, size_t *index){

--- a/dodo.c
+++ b/dodo.c
@@ -868,15 +868,69 @@ EXIT:
 }
 
 
+/* frees the elements of the linked list of instructions
+ * allocated while parsing
+ */
+void scrub(struct Program *p)
+{
+    struct Instruction *now = 0;
+    struct Instruction *next = 0;
+    if ( p->start ){
+        now = p->start;
+        do {
+            next = now->next;
+            free(now);
+            now = next;
+        } while( next );
+    }
+    p->start = NULL;
+}
+
+int repl(struct Program *p){
+    int exit_code = EXIT_FAILURE;
+    char line[4096]; /* FIXME: Perhaps use slurp-like behaviour instead */
+
+    /* FIXME: doesn't handle quit command */
+    while( 1 ){
+        printf("dodo: ");
+        p->source = fgets(line, sizeof(line), stdin);
+
+        if ( ! p->source ){
+            printf("fgets failed in repl\n");
+            exit_code = feof(stdin)? EXIT_SUCCESS : EXIT_FAILURE;
+            goto EXIT;
+        }
+
+        if ( parse(p) ){
+            printf("Parsing failed\n");
+            exit_code = EXIT_FAILURE;
+            goto EXIT;
+        }
+
+        if ( execute(p) ){
+            printf("Execution failed\n");
+            exit_code = EXIT_FAILURE;
+            goto EXIT;
+        }
+        scrub(p);
+    }
+
+EXIT:
+    /* force null to stop free() */
+    p->source = NULL;
+    return exit_code;
+}
+
+
 
 /***** main *****/
 void usage(void){
     puts("dodo - scriptable in place file editor\n"
-         "dodo takes a single argument of <filename>\n"
+         "In non-interactive mode, dodo takes a single argument of <filename>\n"
          "and will read commands from stdin\n"
          "\n"
          "example:\n"
-         "  dodo <filename> <<EOF\n"
+         "  dodo [-i|--interactive] <filename> <<EOF\n"
          "  b6        # goto byte 6\n"
          "  e/world/  # check for string 'world'\n"
          "  w/hello/  # write string 'hello'\n"
@@ -897,11 +951,11 @@ void usage(void){
 
 int main(int argc, char **argv){
     int exit_code = EXIT_SUCCESS;
+    int do_repl = 0;
     struct Program p = {0};
-    struct Instruction *now = 0;
-    struct Instruction *next = 0;
 
-    if(    argc != 2
+    if(    argc < 2
+        || argc > 3
         || !strcmp("--help", argv[1])
         || !strcmp("-h", argv[1])
     ){
@@ -909,49 +963,55 @@ int main(int argc, char **argv){
         exit(EXIT_FAILURE);
     }
 
-    /* read program into source */
-    p.source = slurp(stdin);
-    if( ! p.source ){
-        puts("Reading program failed");
-        exit_code = EXIT_FAILURE;
-        goto EXIT;
+    /* catch 'interactive' command line argument */
+    if (    argc == 3
+         && (!strcmp("--interactive", argv[1])
+         || !strcmp("-i", argv[1]))){
+        do_repl = 1;
     }
 
-    /* parse program */
-    if( parse(&p) ){
-        puts("Parsing program failed");
-        exit_code = EXIT_FAILURE;
-        goto EXIT;
+    /* one-shot read and execute if we're not heading into the repl */
+    if ( ! do_repl )
+    {
+        /* read program into source */
+        p.source = slurp(stdin);
+        if( ! p.source ){
+            puts("Reading program failed");
+            exit_code = EXIT_FAILURE;
+            goto EXIT;
+        }
+
+        /* parse program */
+        if( parse(&p) ){
+            puts("Parsing program failed");
+            exit_code = EXIT_FAILURE;
+            goto EXIT;
+        }
     }
 
     /* open file */
-    p.file = fopen(argv[1], "r+b");
+    p.file = fopen(argv[1 + do_repl], "r+b");
     if( ! p.file ){
-        printf("Failed to open specified file '%s'\n", argv[1]);
+        printf("Failed to open specified file '%s'\n", argv[1 + do_repl]);
         exit_code = EXIT_FAILURE;
         goto EXIT;
     }
 
-    /* execute program */
-    if( execute(&p) ){
-        puts("Program execution failed");
-        exit_code = EXIT_FAILURE;
-        goto EXIT;
+    if ( do_repl ) {
+        /* execute the repl */
+        repl(&p);
+    } else {
+        /* execute program */
+        if( execute(&p) ){
+            puts("Program execution failed");
+            exit_code = EXIT_FAILURE;
+            goto EXIT;
+        }
     }
 
 EXIT:
 
-    /* free the elements of the linked list of instructions allocated while
-     * parsing, if parsing was indeed done
-     */
-    if ( p.start ){
-        now = p.start;
-        do {
-            next = now->next;
-            free(now);
-            now = next;
-        } while( next );
-    }
+    scrub(&p);
 
     if( p.buf ){
         free(p.buf);

--- a/dodo.c
+++ b/dodo.c
@@ -927,17 +927,11 @@ int repl(struct Program *p){
             goto EXIT;
         }
 
-        if ( parse(p) ){
-            printf("Parsing failed\n");
-            exit_code = EXIT_FAILURE;
-            goto EXIT;
-        }
+        /* note we don't error-out on parse or execute,
+         * keep the repl rolling */
+        parse(p);
+        execute(p);
 
-        if ( execute(p) ){
-            printf("Execution failed\n");
-            exit_code = EXIT_FAILURE;
-            goto EXIT;
-        }
         scrub(p);
     }
 

--- a/dodo.c
+++ b/dodo.c
@@ -922,8 +922,12 @@ int repl(struct Program *p){
         p->source = fgets(line, sizeof(line), stdin);
 
         if ( ! p->source ){
-            printf("fgets failed in repl\n");
-            exit_code = feof(stdin)? EXIT_SUCCESS : EXIT_FAILURE;
+            if ( feof(stdin) ){
+                exit_code = EXIT_SUCCESS;
+            } else {
+                printf("fgets failed in repl\n");
+                exit_code = EXIT_FAILURE;
+            }
             goto EXIT;
         }
 

--- a/dodo.c
+++ b/dodo.c
@@ -319,7 +319,7 @@ struct Instruction * parse_print(char *source, size_t *index){
     if( isdigit(source[*index]) ){
         ret = parse_number(i, source, index);
         if (ret == 0)
-            free(ret);
+            free(i);
         return ret;
     }
 
@@ -352,7 +352,7 @@ struct Instruction * parse_byte(char *source, size_t *index){
 
     ret = parse_number(i, source, index);
     if (ret == 0)
-        free(ret);
+        free(i);
 
     return ret;
 }

--- a/test.sh
+++ b/test.sh
@@ -9,10 +9,12 @@ set -eu
 TESTFILENAME=$(mktemp) || exit
 VALGRINDOPTS="--track-origins=yes --error-exitcode=1 --leak-check=full --show-reachable=yes"
 
-echo -e "\nWriting file"
-cat <<EOF > "$TESTFILENAME"
+make_test_file() {
+    echo -e "\nWriting file"
+    cat <<EOF > "$TESTFILENAME"
 hello world how are you mutter mutter sl/ash
 EOF
+}
 
 warn() {
     if [[ -e $TESTFILENAME ]] ; then
@@ -20,36 +22,43 @@ warn() {
         exit 1
     fi
 }
-trap warn EXIT
-
-echo -e "\nRunning dodo"
-valgrind $VALGRINDOPTS ./dodo "$TESTFILENAME" <<EOF
-    p          # print 100 bytes
-    p5         # print 5 bytes ('hello')
-    e/hello/   # expect string 'hello'
-    b6         # goto byte 6 in file
-    e/world/   # expect string 'world'
-    w/marge/   # write string 'marge' (writes over 'world')
-    b38
-    e/sl\/ash/ # expect string 'sl/ash'
-    w/slashy/  # write over string 'sl/ash' with 'slashy'
-    q          # quit
+do_test() {
+    [ -z "$1" ] && exit
+    echo -e "\nRunning $1"
+    valgrind $VALGRINDOPTS $1 "$TESTFILENAME" <<EOF
+        p          # print 100 bytes
+        p5         # print 5 bytes ('hello')
+        e/hello/   # expect string 'hello'
+        b6         # goto byte 6 in file
+        e/world/   # expect string 'world'
+        w/marge/   # write string 'marge' (writes over 'world')
+        b38
+        e/sl\/ash/ # expect string 'sl/ash'
+        w/slashy/  # write over string 'sl/ash' with 'slashy'
+        q          # quit
 EOF
 
 
-echo -e "\nComparing output"
-GOT=`cat "$TESTFILENAME"`
-EXPECTED="hello marge how are you mutter mutter slashy"
+    echo -e "\nComparing output"
+    GOT=`cat "$TESTFILENAME"`
+    EXPECTED="hello marge how are you mutter mutter slashy"
 
-if [ ! "$GOT" = "$EXPECTED" ]; then
-    echo -e "\nTest failed:"
-    echo "Got '$GOT'"
-    echo "Expected '$EXPECTED'"
-    # do not clean up on failure to allow inspection of file
-    #rm -f -- "$TESTFILENAME"
-    exit 1
-fi
+    if [ ! "$GOT" = "$EXPECTED" ]; then
+        echo -e "\nTest failed:"
+        echo "Got '$GOT'"
+        echo "Expected '$EXPECTED'"
+        # do not clean up on failure to allow inspection of file
+        #rm -f -- "$TESTFILENAME"
+        exit 1
+    fi
+}
 
+trap warn EXIT
+
+for dodo in "./dodo" "./dodo -i"; do
+    make_test_file
+    do_test "$dodo"
+done
 
 echo -e "\nAll green"
 


### PR DESCRIPTION
Does what it says on the tin.

The repl I have implemented cannot be quit out of using the quit commend. It is impossible to tell if a quit command was implicit or explicit, so it will only exit the loop on EOF. In short, the repl reads a line, parses it, and executes it. In order to maintain program state, it keeps the same `struct Program` lying around between iterations and simply re-reads a line of code in to the source field, parses it, and executes it.

Also fixes some memory leaks I encountered while developing the repl and having parse failures.
