### PR TITLE
Implement line command, misc style adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ dodo currently supports the following commands and syntax:
 
 print specified number of bytes, if number is not specified will default to 100
 
+**line**:
+
+	lnumber
+
+place cursor at the start of 'number'-th line.
+Warning: this may be expensive in large files
+
+
 **expect:**
 
     e/string/

--- a/dodo.1
+++ b/dodo.1
@@ -63,6 +63,13 @@ pnumber
 
 print specified number of bytes, if number is not specified will default to 100
 .IR
+.IP "\fIline\fR"
+.br
+lnumber
+
+place cursor at the start of 'number'-th line.
+Warning: this may be expensive in large files
+.IR
 .IP "\fIexpect\fR"
 .br
 e/string/

--- a/dodo.c
+++ b/dodo.c
@@ -984,7 +984,7 @@ int repl(struct Program *p){
 
     /* FIXME: doesn't handle quit command */
     while( 1 ){
-        printf("dodo: ");
+        printf("dodo [%d]: ", p->offset);
         p->source = fgets(line, sizeof(line), stdin);
 
         if( ! p->source ){

--- a/dodo.c
+++ b/dodo.c
@@ -324,8 +324,9 @@ struct Instruction * parse_print(char *source, size_t *index){
      */
     if( isdigit(source[*index]) ){
         ret = parse_number(i, source, index);
-        if(ret == 0)
+        if( ret == 0 ){
             free(i);
+        }
         return ret;
     }
 
@@ -357,8 +358,9 @@ struct Instruction * parse_byte(char *source, size_t *index){
     }
 
     ret = parse_number(i, source, index);
-    if(ret == 0)
+    if( ret == 0 ){
         free(i);
+    }
 
     return ret;
 }
@@ -393,8 +395,9 @@ struct Instruction * parse_line(char *source, size_t *index){
         ret = 0;
     }
 
-    if(ret == 0)
+    if( ret == 0 ){
         free(i);
+    }
 
     return ret;
 }
@@ -424,8 +427,9 @@ struct Instruction * parse_expect(char *source, size_t *index){
     }
 
     ret = parse_string(i, source, index);
-    if(ret == 0)
+    if( ret == 0 ){
         free(i);
+    }
 
     return ret;
 }
@@ -454,8 +458,9 @@ struct Instruction * parse_write(char *source, size_t *index){
             break;
     }
     ret = parse_string(i, source, index);
-    if(ret == 0)
+    if( ret == 0 ){
         free(i);
+    }
 
     return ret;
 }

--- a/dodo.c
+++ b/dodo.c
@@ -772,7 +772,7 @@ int eval_line(struct Program *p, struct Instruction *cur){
     char buffer[1024];
     int observed = 0;
     int i = 0;
-    size_t read = 0;
+    size_t nread = 0;
 
     /* first things first; seek to start of file */
     if( fseek(p->file, 0, SEEK_SET) ){
@@ -786,8 +786,8 @@ int eval_line(struct Program *p, struct Instruction *cur){
         return 0;
     }
 
-    while( (read = fread(buffer, 1, sizeof(buffer), p->file)) ){
-        for( i = 0; i < read; i++ ){
+    while( (nread = fread(buffer, 1, sizeof(buffer), p->file)) ){
+        for( i = 0; i < nread; i++ ){
             if( buffer[i] == '\n' && ++observed >= cur->argument.num - 1 ){
                 /* +1 to skip over \n */
                 p->offset += i + 1;
@@ -798,7 +798,7 @@ int eval_line(struct Program *p, struct Instruction *cur){
                 return 0;
             }
         }
-        p->offset += read;
+        p->offset += nread;
     }
 
     printf("eval_line: read error before reaching line %d\n", cur->argument.num);

--- a/t/tests/line.dodo
+++ b/t/tests/line.dodo
@@ -1,0 +1,13 @@
+l2
+e/this/
+w/here/
+
+l3
+e/hey hey/
+w/oi look/
+
+l4
+e/alrighty/
+
+l1
+e/line/

--- a/t/tests/line.in
+++ b/t/tests/line.in
@@ -1,0 +1,4 @@
+line one
+this is line number two
+hey hey it's the third line guys
+alrighty, I'll see myself out

--- a/t/tests/line.out
+++ b/t/tests/line.out
@@ -1,0 +1,4 @@
+line one
+here is line number two
+oi look it's the third line guys
+alrighty, I'll see myself out


### PR DESCRIPTION
I have implemented a "naïve first attempt" at the line command in response to #6, permitting dodo to jump to specific line numbers. Immediately, I can see two issues:

1) dodo may consume a lot of the file before finding the (n-1)th line break
2) dodo will fseek to the beginning of the file, whereas relative line jumping should be possible, although less clear to implement and prone to more bugs

As you state in #6, we can put the responsibility for (1) onto the user, however I'm not sure if we can say the same about (2) or not. Some simple testing has been added for the line command but we are still lacking the ability to test failure conditions, which limits the amount of testing we can add.

This command makes me wonder if we should also extend the byte command to allow relative byte jumps. It's useful to jump to a certain line, but it is also then useful to jump to a certain section of that line, and currently the only way of doing this would be `e/foo/w/foo/` to jump over `foo` at the start of a line, which is far from ideal.

---

I have also aligned some if blocks with the style used throughout the rest of the source and added a little extra something to the interactive prompt to show the current cursor position in bytes .
